### PR TITLE
feat: 약관 동의 및 안내 페이지 라우팅 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ function App(): JSX.Element {
           {/* Boards */}
           <Route path="/boards" element={<BoardsPage />} />
           <Route path="/boards/:category" element={<BoardsPage />} />
-          <Route path="/boards/:category/new" element={<BoardNewPage />} />
+          <Route path="/boards/new" element={<BoardNewPage />} />
           <Route path="/boards/:category/:postId" element={<BoardDetailPage />} />
           <Route path="/boards/:category/:postId/edit" element={<BoardEditPage />} />
           <Route path="/boards/:category/:postId/applicants" element={<ApplicantsPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,16 +25,22 @@ import ProjectStatusPage from './pages/projects/ProjectStatusPage'
 import ProjectMeetingPage from './pages/projects/ProjectMeetingPage'
 import ProjectChatPage from './pages/projects/ProjectChatPage'
 import Layout from './components/common/Layout'
+import LandingPage from './pages/LandingPage'
+import TermsPage from './pages/policy/TermsPage'
+import PrivacyPage from './pages/policy/PrivacyPage'
 
 function App(): JSX.Element {
   return (
     <BrowserRouter>
       <Routes>
         {/* Public */}
-        <Route element={<Layout />}>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/login/oauth2/code/google" element={<AuthCallBackPage />} />
+        <Route element={<Layout isLoggedIn={false} />}>
+          <Route path="/" element={<LandingPage />} />
+        </Route>
 
+        <Route element={<Layout isLoggedIn={true} />}>
+          <Route path="/policy/privacy" element={<PrivacyPage />}></Route>
+          <Route path="/policy/terms" element={<TermsPage />}></Route>
           {/* Boards */}
           <Route path="/boards" element={<BoardsPage />} />
           <Route path="/boards/:category" element={<BoardsPage />} />
@@ -57,6 +63,7 @@ function App(): JSX.Element {
         </Route>
 
         <Route path="/start" element={<StartPage />} />
+        <Route path="/login/oauth2/code/google" element={<AuthCallBackPage />} />
       </Routes>
     </BrowserRouter>
   )

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -2,11 +2,15 @@ import { Outlet } from 'react-router-dom'
 import Header from './Header'
 import Footer from './Footer'
 
-const Layout = () => (
+interface LayoutProps {
+  isLoggedIn: boolean
+}
+
+const Layout: React.FC<LayoutProps> = ({ isLoggedIn }) => (
   <div className="font-pretendard flex min-h-screen flex-col">
-    <Header isLoggedIn={true} />
-    <main className="flex-1">
-      <Outlet /> {/* 여기서 하위 라우트가 바뀜 */}
+    <Header isLoggedIn={isLoggedIn} />
+    <main className="flex-1 bg-gray-50">
+      <Outlet />
     </main>
     <Footer />
   </div>

--- a/src/pages/policy/PrivacyPage.tsx
+++ b/src/pages/policy/PrivacyPage.tsx
@@ -1,0 +1,5 @@
+import type { JSX } from 'react'
+
+export default function PrivacyPage(): JSX.Element {
+  return <div>This is Privacy Page</div>
+}

--- a/src/pages/policy/TermsPage.tsx
+++ b/src/pages/policy/TermsPage.tsx
@@ -1,0 +1,5 @@
+import type { JSX } from 'react'
+
+export default function TermsPage(): JSX.Element {
+  return <div>This is Terms Page</div>
+}


### PR DESCRIPTION
## 개요 (Overview)

약관 동의 및 안내 페이지로 이동할 수 있도록 라우팅 설정을 추가했습니다.
서비스 온보딩 과정에서 사용자가 약관을 확인하고 동의할 수 있는 흐름을 구축하기 위한 초기 작업입니다.

## 변경 사항 (Changes)

임시 페이지 파일(PrivacyPage.tsx, TermsPage.tsx) 생성 및 기본 UI 구조 적용
/policy/privacy, /policy/terms 경로에 약관 동의 및 안내 페이지 라우팅 추가

## 변경 유형 (Change Type)

- [ ] 🐛 Bug Fix: 버그 수정
- [x] ✨ Feature: 새로운 기능 추가
- [ ] 💄 UI/UX: 사용자 인터페이스 변경
- [ ] ♻️ Refactor: 코드 리팩토링 (기능 변경 없음)
- [ ] 🚀 Performance: 성능 개선
- [ ] 🧪 Test: 테스트 추가 또는 수정
- [ ] 🔧 Config: 구성 파일 변경
- [ ] 📝 Docs: 문서 변경
- [ ] 🔀 Merge: 브랜치 병합
- [ ] 🗑️ Chore: 기타 변경사항 (빌드 스크립트, 종속성 등)

## 관련 이슈 (Related Issues)

<!--
  이 PR과 관련된 이슈를 링크하세요. GitHub의 키워드를 사용하여 자동으로 이슈를 연결할 수 있습니다.
  예: Closes #123, Fixes #456, Resolves #789
-->



