### PR TITLE
feat: Landing, Start, Boards 페이지 컴포넌트 구현

### DIFF
--- a/src/components/feature/auth/TermsConsentModal.tsx
+++ b/src/components/feature/auth/TermsConsentModal.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react'
+import Modal from '@/components/common/Modal'
+import Checkbox from '@/components/atoms/Checkbox'
+
+interface TermsConsentModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => void
+}
+
+const TermsConsentModal: React.FC<TermsConsentModalProps> = ({ isOpen, onClose, onConfirm }) => {
+  const [isChecked, setIsChecked] = useState(false)
+
+  const description = (
+    <div className="flex flex-col gap-8">
+      <p className="text-b5-medium text-gray-800">
+        마이페이지에서 프로필을 설정하고 로컬잇과 함께 온라인 IT 협업을 효과적으로 진행해 보세요.
+        <br />
+        프로필 설정 이전에는 둘러보기만 가능합니다.
+      </p>
+
+      {/* 체크박스 */}
+      <div className="flex items-center gap-2">
+        <Checkbox checked={isChecked} onChange={() => setIsChecked((prev) => !prev)} />
+        <span className="text-b5-medium text-gray-550">
+          모든{' '}
+          <a href="/policy/terms" target="_blank" className="text-locallit-red-500">
+            이용약관
+          </a>{' '}
+          및{' '}
+          <a href="/policy/privacy" target="_blank" className="text-locallit-red-500">
+            개인정보 처리방침
+          </a>
+          에 동의합니다.
+        </span>
+      </div>
+    </div>
+  )
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title="만나서 반갑습니다!"
+      description={description}
+      cancelLabel="둘러보기"
+      confirmLabel="프로필 설정하러 가기"
+      onCancel={onClose}
+      onConfirm={onConfirm}
+      cancelDisabled={!isChecked}
+      confirmDisabled={!isChecked}
+    />
+  )
+}
+
+export default TermsConsentModal

--- a/src/components/feature/boards/BoardItem.tsx
+++ b/src/components/feature/boards/BoardItem.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { Eye, File } from 'lucide-react'
+import { Tag } from '@/components/atoms/Tag'
+
+interface BoardItemProps {
+  title: string
+  timeAgo: string
+  deadline: string
+  field: string
+  tags: string[]
+  views: number
+  bookmarks: number
+  onClick?: () => void
+}
+
+const BoardItem: React.FC<BoardItemProps> = ({
+  title,
+  timeAgo,
+  deadline,
+  field,
+  tags,
+  views,
+  bookmarks,
+  onClick,
+}) => {
+  return (
+    <div
+      onClick={onClick}
+      className="flex w-full cursor-pointer items-center justify-between bg-gray-100 px-[25px] py-4"
+    >
+      {/* 왼쪽 영역: 제목 + 부가정보 */}
+      <div className="flex flex-col gap-[7px]">
+        <h3 className="text-b5-bold text-gray-850">{title}</h3>
+        <p className="text-l1-medium flex gap-[7px] text-gray-600">
+          {timeAgo} <span className="text-gray-400">·</span> 모집 마감일: {deadline}{' '}
+          <span className="text-gray-400">·</span> 모집 포지션: {field}
+        </p>
+      </div>
+
+      {/* 오른쪽 영역: 태그 + 통계 */}
+      <div className="flex flex-col items-end gap-2">
+        {/* 태그 리스트 */}
+        <div className="flex flex-wrap justify-end gap-[5px]">
+          {tags.map((tag) => (
+            <Tag key={tag} label={tag} />
+          ))}
+        </div>
+
+        {/* 조회수 / 북마크 */}
+        <div className="text-l1-medium flex items-center gap-[17px] text-gray-600">
+          <div className="flex gap-[10px]">
+            <Eye className="h-6 w-6" />
+            {views}
+          </div>
+          <div className="flex gap-[10px]">
+            <File className="h-6 w-6" />
+            {bookmarks}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default BoardItem

--- a/src/components/feature/boards/BoardsPageHeader.tsx
+++ b/src/components/feature/boards/BoardsPageHeader.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import SearchBar from '../common/SearchBar'
+import Button from '@/components/atoms/Button'
+import { ChevronLeft } from 'lucide-react'
+
+interface BoardsPageHeaderProps {
+  /** 중앙에 표시될 페이지 제목 */
+  title: string
+  /** 왼쪽 화살표 클릭 시 동작 (없으면 숨김) */
+  onBackClick?: () => void
+  /** 검색창 (값 + 변경 핸들러 제공 시 노출) */
+  searchValue?: string
+  onSearchChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  /** 오른쪽 버튼 텍스트 + 클릭 핸들러 제공 시 노출 */
+  rightButtonLabel?: string
+  onRightButtonClick?: () => void
+}
+
+const BoardsPageHeader: React.FC<BoardsPageHeaderProps> = ({
+  title,
+  onBackClick,
+  searchValue,
+  onSearchChange,
+  rightButtonLabel,
+  onRightButtonClick,
+}) => {
+  return (
+    <header className="flex w-full items-center justify-between bg-gray-50">
+      {/* 왼쪽: 화살표 + 제목 */}
+      <div className="flex items-center gap-4">
+        {onBackClick && (
+          <button
+            type="button"
+            onClick={onBackClick}
+            aria-label="뒤로가기"
+            className="flex h-8 w-8 items-center justify-center rounded-lg hover:bg-gray-100"
+          >
+            <ChevronLeft size={36} className="text-gray-500" />
+          </button>
+        )}
+        <h1 className="text-s1-bold">{title}</h1>
+      </div>
+
+      {/* 오른쪽: SearchBar 또는 Button */}
+      <div className="flex items-center">
+        {searchValue !== undefined && onSearchChange ? (
+          <SearchBar value={searchValue} onChange={onSearchChange} />
+        ) : rightButtonLabel && onRightButtonClick ? (
+          <Button shape="square" onClick={onRightButtonClick}>
+            {rightButtonLabel}
+          </Button>
+        ) : null}
+      </div>
+    </header>
+  )
+}
+
+export default BoardsPageHeader

--- a/src/components/feature/boards/InputField.tsx
+++ b/src/components/feature/boards/InputField.tsx
@@ -1,0 +1,55 @@
+import { Calendar } from 'lucide-react'
+import clsx from 'clsx'
+import { Tag } from '@/components/atoms/Tag' // Tag atom import
+
+type InputFieldVariant = 'default' | 'selected' | 'techTag' | 'error'
+
+interface InputFieldProps {
+  label?: string
+  value?: string
+  variant?: InputFieldVariant
+  placeholder?: string
+  tags?: string[]
+  errorMessage?: string
+  onRemoveTag?: (tag: string) => void
+}
+
+export function InputField({
+  label,
+  value,
+  variant = 'default',
+  placeholder = 'Text',
+  tags = [],
+  errorMessage,
+  onRemoveTag,
+}: InputFieldProps) {
+  return (
+    <div className="w-[562px]">
+      {/* default, selected, error 공통 input */}
+      {(variant === 'default' || variant === 'selected' || variant === 'error') && (
+        <div className="flex min-h-[56px] items-center justify-between rounded-lg bg-gray-200 px-[20px] py-[14px]">
+          <span
+            className={clsx('text-b4-medium', !value && variant === 'default' && 'text-gray-500')}
+          >
+            {value || placeholder}
+          </span>
+          <Calendar className="h-6 w-6 text-neutral-500" />
+        </div>
+      )}
+
+      {/* techTag variant */}
+      {variant === 'techTag' && (
+        <div className="flex flex-wrap gap-[10px] rounded-lg bg-gray-200 px-[20px] py-[14px]">
+          {tags.map((tag, idx) => (
+            <Tag key={idx} label={tag} onRemove={() => onRemoveTag?.(tag)} />
+          ))}
+        </div>
+      )}
+
+      {/* error 메시지 */}
+      {variant === 'error' && errorMessage && (
+        <p className="text-b5-medium mt-[7px] text-start text-red-500">* {errorMessage}</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/feature/boards/Page.tsx
+++ b/src/components/feature/boards/Page.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import clsx from 'clsx'
+
+interface PageProps {
+  number: number
+  selected?: boolean
+  disabled?: boolean
+  onClick?: () => void
+}
+
+export const Page: React.FC<PageProps> = ({
+  number,
+  selected = false,
+  disabled = false,
+  onClick,
+}) => {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={!disabled ? onClick : undefined}
+      className={clsx(
+        'flex h-[32px] w-[32px] items-center justify-center rounded-[8px] text-sm font-medium transition-colors',
+        disabled
+          ? 'bg-gray-0 cursor-not-allowed border border-gray-400 text-gray-400'
+          : selected
+            ? 'bg-locallit-red-500 border border-transparent text-white'
+            : 'border border-gray-400 bg-white text-gray-800 hover:bg-gray-50',
+      )}
+    >
+      {number}
+    </button>
+  )
+}

--- a/src/components/feature/boards/Pagination.tsx
+++ b/src/components/feature/boards/Pagination.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { Page } from './Page'
+
+interface PaginationProps {
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+export const Pagination: React.FC<PaginationProps> = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}) => {
+  if (!totalPages || totalPages <= 0) return null
+
+  const chunkSize = 5
+  const chunkIndex = Math.floor((currentPage - 1) / chunkSize)
+  const startPage = chunkIndex * chunkSize + 1
+  const endPage = Math.min(startPage + chunkSize - 1, totalPages)
+
+  const pages = Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i)
+
+  const hasPrevChunk = startPage > 1
+  const hasNextChunk = endPage < totalPages
+
+  const goPrevPage = () => onPageChange(Math.max(1, currentPage - 1))
+  const goNextPage = () => onPageChange(Math.min(totalPages, currentPage + 1))
+  const goPrevChunk = () => onPageChange(startPage - 1)
+  const goNextChunk = () => onPageChange(endPage + 1)
+
+  return (
+    <div className="text-l1-medium mt-8 flex h-8 w-full items-center justify-between text-gray-800">
+      <div className="flex h-8 items-center">
+        {currentPage > 1 ? (
+          <button
+            type="button"
+            onClick={goPrevPage}
+            className="bg-gray-0 flex h-8 items-center justify-center rounded-lg border border-gray-400 px-[10px] py-1"
+          >
+            이전 페이지
+          </button>
+        ) : (
+          <span className="invisible flex h-8 items-center px-3 py-1">이전 페이지</span>
+        )}
+      </div>
+
+      <div className="flex h-8 items-center justify-center gap-[5px]">
+        {hasPrevChunk && (
+          <button
+            type="button"
+            className="bg-gray-0 flex h-8 w-8 items-center justify-center rounded-lg border border-gray-400"
+            onClick={goPrevChunk}
+            aria-label="이전 구간"
+          >
+            …
+          </button>
+        )}
+
+        {pages.map((num) => (
+          <Page
+            key={num}
+            number={num}
+            selected={num === currentPage}
+            disabled={false}
+            onClick={() => onPageChange(num)}
+          />
+        ))}
+
+        {hasNextChunk && (
+          <button
+            type="button"
+            className="bg-gray-0 flex h-8 w-8 items-center justify-center rounded-lg border border-gray-400"
+            onClick={goNextChunk}
+            aria-label="다음 구간"
+          >
+            …
+          </button>
+        )}
+      </div>
+
+      <div className="flex h-8 items-center">
+        {currentPage < totalPages ? (
+          <button
+            type="button"
+            onClick={goNextPage}
+            className="bg-gray-0 flex h-8 items-center justify-center rounded-lg border border-gray-400 px-[10px] py-1"
+          >
+            다음 페이지
+          </button>
+        ) : (
+          <span className="invisible flex h-8 items-center px-3 py-1">다음 페이지</span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/feature/common/SearchBar.tsx
+++ b/src/components/feature/common/SearchBar.tsx
@@ -13,7 +13,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   onChange,
 }) => {
   return (
-    <div className="flex w-full max-w-[320px] items-center gap-2 rounded-xl bg-gray-200 px-4 py-3">
+    <div className="flex w-[320px] items-center gap-2 rounded-xl bg-gray-200 px-4 py-3">
       <FiSearch className="text-gray-500" size={20} />
       <input
         type="text"

--- a/src/components/feature/landing/HeroSection.tsx
+++ b/src/components/feature/landing/HeroSection.tsx
@@ -1,0 +1,21 @@
+import Button from '@/components/atoms/Button'
+import React, { useState } from 'react'
+import ScrollDown from './ScrollDown'
+import { InputField } from '../boards/InputField'
+import { Pagination } from '../boards/Pagination'
+
+interface HeroSectionProps {
+  onScrollDown: () => void
+}
+
+const HeroSection: React.FC<HeroSectionProps> = ({ onScrollDown }) => {
+  return (
+    <section className="bg-gray-0 relative flex h-screen flex-col items-center justify-center">
+      <h1 className="text-s1-bold text-gray-900">서비스 메인 카피 영역</h1>
+
+      <ScrollDown onClick={onScrollDown} />
+    </section>
+  )
+}
+
+export default HeroSection

--- a/src/components/feature/landing/ScrollDown.tsx
+++ b/src/components/feature/landing/ScrollDown.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import ArrowDownIcon from '@/assets/icons/arrow-down.svg'
+
+interface ScrollDownProps {
+  onClick: () => void
+}
+
+const ScrollDown: React.FC<ScrollDownProps> = ({ onClick }) => {
+  return (
+    <div
+      className="absolute bottom-20 left-1/2 flex h-[56px] w-[36px] -translate-x-1/2 animate-bounce cursor-pointer justify-center"
+      onClick={onClick}
+    >
+      <img src={ArrowDownIcon} alt="scroll down" className="h-[56px] w-[36px]" />
+    </div>
+  )
+}
+
+export default ScrollDown

--- a/src/components/feature/landing/ServiceIntro.tsx
+++ b/src/components/feature/landing/ServiceIntro.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const ServiceIntro: React.FC = () => {
+  return (
+    <section className="bg-gray-0 flex h-screen flex-col items-center justify-center">
+      <h2 className="text-3xl font-semibold text-gray-900">서비스 소개</h2>
+      <p className="mt-4 max-w-xl text-center text-gray-600">
+        여기에 서비스 설명이 들어갑니다. 이후 섹션이 계속 아래로 이어질 수 있습니다.
+      </p>
+    </section>
+  )
+}
+
+export default ServiceIntro


### PR DESCRIPTION
## 개요 (Overview)

- Landing, Start(로그인), Boards 페이지의 기본 구조를 구현했습니다.
- 각 페이지의 섹션별 Feature 컴포넌트를 생성하여, 추후 API 연동 및 세부 로직 구현을 위한 기반을 마련했습니다.

## 변경 사항 (Changes)

1. Landing 페이지
- HeroSection, IntroSection 등 주요 섹션 컴포넌트 구현
- 서비스 소개 및 CTA 버튼 기본 UI 구성
2. Start(로그인) 페이지
- 로그인 버튼, 회원 안내 영역 구성
3. Boards 페이지
- BoardItem, BoardsPageHeader, Pagination 등 Feature 컴포넌트 구현

## 변경 유형 (Change Type)

- [x] ✨ Feature: 새로운 기능 추가
- [x] 💄 UI/UX: 사용자 인터페이스 변경

## 관련 이슈 (Related Issues)

<!--
  이 PR과 관련된 이슈를 링크하세요. GitHub의 키워드를 사용하여 자동으로 이슈를 연결할 수 있습니다.
  예: Closes #123, Fixes #456, Resolves #789
-->
