### PR TITLE
feat: Landing 페이지 기본 구조 구현

### DIFF
--- a/src/assets/icons/arrow-down.svg
+++ b/src/assets/icons/arrow-down.svg
@@ -1,0 +1,5 @@
+<svg width="36" height="56" viewBox="0 0 36 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 13.5L18 22.5L27 13.5" stroke="#E1DDDC" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 23.5L18 32.5L27 23.5" stroke="#C9C4C3" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 33.5L18 42.5L27 33.5" stroke="#928D8C" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,0 +1,33 @@
+import React, { useRef, useState } from 'react'
+import HeroSection from '@/components/feature/landing/HeroSection'
+import ServiceIntro from '@/components/feature/landing/ServiceIntro'
+import TermsConsentModal from '@/components/feature/auth/TermsConsentModal'
+
+const LandingPage: React.FC = () => {
+  const introRef = useRef<HTMLDivElement | null>(null)
+  const [showModal, setShowModal] = useState(true)
+
+  const handleScrollDown = () => {
+    introRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }
+
+  return (
+    <div>
+      <HeroSection onScrollDown={handleScrollDown} />
+      <div ref={introRef}>
+        <ServiceIntro />
+      </div>
+
+      <TermsConsentModal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)} // "둘러보기" 눌렀을 때 닫힘
+        onConfirm={() => {
+          console.log('프로필 설정 페이지로 이동')
+          setShowModal(false)
+        }}
+      />
+    </div>
+  )
+}
+
+export default LandingPage


### PR DESCRIPTION
## 개요 (Overview)

서비스의 첫 진입점인 Landing 페이지의 기본 구조를 구현했습니다.

## 변경 사항 (Changes)

- HeroSection - 메인 문구
- ServiceIntro - 서비스 소개 및 기능 요약 섹션
- TermsConsentModal - 로그인 후 약관 동의 및 안내 페이지로 이동할 수 있는 모달, 테스트를 위한 구현

## 변경 유형 (Change Type)
- [x] ✨ Feature: 새로운 기능 추가
- [x] 💄 UI/UX: 사용자 인터페이스 변경

## 관련 이슈 (Related Issues)

<!--
  이 PR과 관련된 이슈를 링크하세요. GitHub의 키워드를 사용하여 자동으로 이슈를 연결할 수 있습니다.
  예: Closes #123, Fixes #456, Resolves #789
-->
