### PR TITLE
feat: Boards 페이지 기본 구조 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "clsx": "^2.1.1",
         "date-fns": "4.1.0",
         "eslint-plugin-prettier": "5.5.4",
+        "lucide-react": "^0.544.0",
         "motion": "12.23.12",
         "react": "19.1.1",
         "react-dom": "19.1.1",
@@ -7928,6 +7929,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "clsx": "^2.1.1",
     "date-fns": "4.1.0",
     "eslint-plugin-prettier": "5.5.4",
+    "lucide-react": "^0.544.0",
     "motion": "12.23.12",
     "react": "19.1.1",
     "react-dom": "19.1.1",

--- a/src/pages/boards/BoardsPage.tsx
+++ b/src/pages/boards/BoardsPage.tsx
@@ -1,5 +1,171 @@
-import type { JSX } from 'react'
+import React, { useState, useEffect } from 'react'
+import CategoryMenuItem from '@/components/atoms/CategoryItem'
+import Chip from '@/components/atoms/Chip'
+import BoardItem from '@/components/feature/boards/BoardItem'
+import BoardsPageHeader from '@/components/feature/boards/BoardsPageHeader'
+import { Pagination } from '@/components/feature/boards/Pagination'
+import Button from '@/components/atoms/Button'
+import Dropdown from '@/components/atoms/Dropdown'
 
-export default function BoardsPage(): JSX.Element {
-  return <div>This is Boards Page</div>
+const BoardsPage: React.FC = () => {
+  // 상단 탭
+  const categories = ['공모전/대회', '사이드 프로젝트', '스터디', '기타']
+  const [selectedCategory, setSelectedCategory] = useState(categories[0])
+
+  // 필터 Chip
+  const chipLabels = ['개발 중심', '기획+디자인', '디자인 중심', '융합 프로젝트']
+  const [selectedChip, setSelectedChip] = useState('개발 중심')
+
+  // 검색어 상태
+  const [searchValue, setSearchValue] = useState('')
+
+  const handleBackClick = () => {
+    setSearchValue('')
+  }
+
+  // 게시글 리스트
+  const posts = Array(5)
+    .fill(null)
+    .map((_, i) => ({
+      id: i + 1,
+      title: '팀 프로젝트 React 기반 프론트엔드 개발자 1명 구합니다',
+      timeAgo: '2시간 전',
+      deadline: '2025.07.31',
+      field: '프론트엔드',
+      tags: ['스택 어쩌고', '스택스택', '조건어쩌고'],
+      views: 133,
+      bookmarks: 133,
+    }))
+
+  // 페이지네이션 상태
+  const [currentPage, setCurrentPage] = useState(1)
+
+  // 드롭다운 상태 (하드코딩 데이터)
+  const positionOptions = ['전체', '기획자', '디자이너', '프론트엔드', '백엔드', '기타']
+  const sortOptions = ['최신순', '마감순', '인기순']
+
+  // 드롭다운 나중에 API로 대체할 부분
+  /*
+  useEffect(() => {
+    async function fetchDropdownData() {
+      try {
+        // const res = await fetch('/api/positions')
+        // const data = await res.json()
+        // setPositionOptions(data.positions)
+
+        // const sortRes = await fetch('/api/sort-options')
+        // const sortData = await sortRes.json()
+        // setSortOptions(sortData.sorts)
+      } catch (error) {
+        console.error('드롭다운 데이터 로드 실패:', error)
+      }
+    }
+
+    fetchDropdownData()
+  }, [])
+  */
+
+  // 검색 필터링 (임시 로직)
+  const trimmedSearch = searchValue.trim() // 공백만 입력된 경우 무시
+  const filteredPosts = trimmedSearch
+    ? posts.filter((post) => post.title.toLowerCase().includes(trimmedSearch.toLowerCase()))
+    : posts
+
+  const isSearching = trimmedSearch.length > 0
+
+  return (
+    <div className="flex min-h-screen flex-col px-[144px] py-[44px] text-start">
+      {/* 상단 헤더 */}
+      <BoardsPageHeader
+        title={isSearching ? `'${trimmedSearch}' 검색 결과` : '팀원 모집하기'}
+        searchValue={searchValue}
+        onSearchChange={(e) => setSearchValue(e.target.value)}
+        onBackClick={isSearching ? () => setSearchValue('') : undefined}
+      />
+
+      {/* 카테고리 탭 */}
+      <div className="border-gray-250 mt-6 flex justify-between border-b-[1.5px] pb-3">
+        <div className="flex gap-[25px]">
+          {categories.map((cat) => (
+            <CategoryMenuItem
+              key={cat}
+              label={cat}
+              selected={selectedCategory === cat}
+              onClick={() => setSelectedCategory(cat)}
+            />
+          ))}
+        </div>
+        <Button variant="secondary">내 모집글 관리</Button>
+      </div>
+
+      {/* 필터 Chip 리스트 */}
+      <div className="border-gray-250 flex flex-wrap justify-start gap-[10px] border-b-[1.5px] py-3">
+        {chipLabels.map((label) => (
+          <Chip
+            key={label}
+            label={label}
+            selected={selectedChip === label}
+            onClick={() => setSelectedChip(label)}
+          />
+        ))}
+      </div>
+
+      {/* 검색 결과 + 드롭다운 + 글쓰기 버튼 */}
+      <div className="mt-8 flex items-center justify-between font-medium text-gray-500">
+        <span className="pt-4">검색 결과 {filteredPosts.length}건</span>
+
+        <div className="flex items-center gap-4">
+          {/* 포지션 드롭다운 */}
+          <Dropdown
+            placeholder="포지션"
+            options={positionOptions}
+            onSelect={(value) => console.log('선택된 포지션:', value)}
+          />
+
+          {/* 정렬 드롭다운 */}
+          <Dropdown
+            placeholder="최신순"
+            options={sortOptions}
+            onSelect={(value) => console.log('선택된 정렬:', value)}
+          />
+
+          {/* 검색 결과 없을 때만 글쓰기 버튼 표시 */}
+          {!searchValue && <Button>글쓰기</Button>}
+        </div>
+      </div>
+
+      {/* 게시글 리스트 */}
+      <div className="mt-4 flex flex-col gap-4">
+        {filteredPosts.length > 0 ? (
+          filteredPosts.map((post) => (
+            <BoardItem
+              key={post.id}
+              title={post.title}
+              timeAgo={post.timeAgo}
+              deadline={post.deadline}
+              field={post.field}
+              tags={post.tags}
+              views={post.views}
+              bookmarks={post.bookmarks}
+              onClick={() => console.log(`${post.title} 클릭`)}
+            />
+          ))
+        ) : (
+          <div className="flex h-[500px] flex-col justify-center gap-[29px] text-center">
+            <p className="text-s1-bold text-gray-1000">'{searchValue}' 검색 결과가 없습니다.</p>
+            <p className="text-b2-medium text-gray-500">
+              다른 카테고리에서 확인해 보시거나 다른 키워드로 검색해 보세요.
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* 페이지네이션 */}
+      <div className="mt-10 mb-16 flex justify-center">
+        <Pagination currentPage={currentPage} totalPages={6} onPageChange={setCurrentPage} />
+      </div>
+    </div>
+  )
 }
+
+export default BoardsPage


### PR DESCRIPTION
## 개요 (Overview)

Boards(팀원 모집) 페이지의 기본 레이아웃과 UI 구조를 구현했습니다.
카테고리 탭, 필터 Chip, 게시글 리스트, 페이지네이션 등 페이지의 주요 요소를 구성하여
추후 API 연동 및 실제 게시글 데이터 렌더링을 위한 기반을 마련했습니다.

## 변경 사항 (Changes)

1. BoardsPage 레이아웃 구성
- 페이지 상단에 BoardsPageHeader 추가 (검색 및 뒤로가기 로직 포함)

2. 카테고리 탭
- CategoryMenuItem 컴포넌트를 이용해 카테고리 선택 기능 구현
- Chip 컴포넌트로 프로젝트 성격(개발 중심, 디자인 중심 등) 필터 구성
- 선택 상태(selectedChip)에 따라 스타일 변경

3. 드롭다운 메뉴
- 포지션 / 정렬 기준(Dropdown 컴포넌트) 구현
- 향후 API 연동으로 대체 예정 (현재는 하드코딩 데이터)

4. 게시글 리스트
- BoardItem 컴포넌트를 이용해 게시글 정보(제목, 태그, 조회수 등) 표시
- 검색 필터링 및 임시 데이터 렌더링 구현

5. 페이지네이션
Pagination 컴포넌트 추가 및 현재 페이지 상태 관리

## 변경 유형 (Change Type)

- [x] ✨ Feature: 새로운 기능 추가
- [x] 💄 UI/UX: 사용자 인터페이스 변경

## 관련 이슈 (Related Issues)

<!--
  이 PR과 관련된 이슈를 링크하세요. GitHub의 키워드를 사용하여 자동으로 이슈를 연결할 수 있습니다.
  예: Closes #123, Fixes #456, Resolves #789
-->
